### PR TITLE
Adding support for uncut pages (issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ There are a few properties that define the behaviour of the component, here they
 | Prop | Type | Default | Role |
 |------|------|---------|------|
 | `orientation` | `string` | `vertical` | Orientation of swipes. `vertical` or `horizontal` for respectively up/down swipes and left/right swipes |
+| `uncutPages` | `boolean` | `false` | If `true`, the pages will be allowed to overflow through the container. The original effect is to keep everything inside the container, but you can set this to `true` to have a more "bookish" effect. |
 | `animationDuration` | `number` | `200` | Duration in ms of the fold/unfold animation |
 | `treshold` | `number` | `10` | Distance in px to swipe before the gesture is activated |
 | `maxAngle` | `number` | `45` | Angle of the page when there's nothing to display before/after |

--- a/dist/index.js
+++ b/dist/index.js
@@ -377,7 +377,9 @@
         var halfHeight = this.getHalfHeight();
         var width = this.getWidth();
         var halfWidth = this.getHalfWidth();
-        var orientation = this.props.orientation;
+        var _props = this.props,
+            orientation = _props.orientation,
+            uncutPages = _props.uncutPages;
 
         var gradientTop = '0 -100px 100px -100px rgba(0,0,0,0.25) inset';
         var gradientLeft = '-100px 0 100px -100px rgba(0,0,0,0.25) inset';
@@ -394,7 +396,7 @@
           container: {
             display: this.state.page === key ? 'block' : 'none',
             height: height,
-            overflow: 'hidden',
+            overflow: uncutPages === false ? 'hidden' : '',
             position: 'relative',
             width: width
           },
@@ -438,7 +440,8 @@
           },
           after: {
             top: orientation === 'vertical' ? halfHeight : 0,
-            left: orientation === 'vertical' ? 0 : halfWidth
+            left: orientation === 'vertical' ? 0 : halfWidth,
+            width: orientation === 'horizontal' ? halfWidth : width
           },
           cut: {
             background: this.props.pageBackground,
@@ -656,6 +659,7 @@
     firstComponent: null,
     lastComponent: null,
     showHint: false,
+    uncutPages: false,
     style: {}
   };
 
@@ -674,6 +678,7 @@
     firstComponent: _propTypes2.default.element,
     lastComponent: _propTypes2.default.element,
     showHint: _propTypes2.default.bool,
+    uncutPages: _propTypes2.default.bool,
     style: _propTypes2.default.object
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ class FlipPage extends Component {
     const halfHeight = this.getHalfHeight()
     const width = this.getWidth()
     const halfWidth = this.getHalfWidth()
-    const {orientation} = this.props
+    const {orientation, uncutPages} = this.props
     const gradientTop = '0 -100px 100px -100px rgba(0,0,0,0.25) inset'
     const gradientLeft = '-100px 0 100px -100px rgba(0,0,0,0.25) inset'
     const gradientBottom = '0 100px 100px -100px rgba(0,0,0,0.25) inset'
@@ -288,7 +288,7 @@ class FlipPage extends Component {
       container: {
         display: this.state.page === key ? 'block' : 'none',
         height: height,
-        overflow: 'hidden',
+        overflow: uncutPages === false ? 'hidden' : '',
         position: 'relative',
         width: width
       },
@@ -332,7 +332,8 @@ class FlipPage extends Component {
       },
       after: {
         top: orientation === 'vertical' ? halfHeight : 0,
-        left: orientation === 'vertical' ? 0 : halfWidth
+        left: orientation === 'vertical' ? 0 : halfWidth,
+        width: orientation === 'horizontal' ? halfWidth : width
       },
       cut: {
         background: this.props.pageBackground,
@@ -494,6 +495,7 @@ FlipPage.defaultProps = {
   firstComponent: null,
   lastComponent: null,
   showHint: false,
+  uncutPages: false,
   style: {},
 }
 
@@ -515,6 +517,7 @@ FlipPage.propTypes = {
   firstComponent: PropTypes.element,
   lastComponent: PropTypes.element,
   showHint: PropTypes.bool,
+  uncutPages: PropTypes.bool,
   style: PropTypes.object
 }
 


### PR DESCRIPTION
Adding support for uncut pages (issue #3).

The property controlling this behavior is `uncutPages`. Its default value is `false`.