### PR TITLE
Documenting height and width props

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ There are a few properties that define the behaviour of the component, here they
 | `lastComponent` | `element` | `null` | Component that will be displayed under the last page |
 | `showHint` | `bool` | `false` | Indicates if the component must hint the user on how it works. Setting this to `true` will lift the bottom of the page 1s after the component is mounted, for 1s |
 | `style` | `object` | `{}` | Additional style for the flipboard |
+| `height` | `number` | `480` | Height for the flipboard |
+| `width` | `number` | `320` | Width for the flipboard |
 
 ## Contribute
 

--- a/src/index.js
+++ b/src/index.js
@@ -497,6 +497,8 @@ FlipPage.defaultProps = {
   showHint: false,
   uncutPages: false,
   style: {},
+  height: 480,
+  width: 320
 }
 
 FlipPage.propTypes = {
@@ -518,7 +520,9 @@ FlipPage.propTypes = {
   lastComponent: PropTypes.element,
   showHint: PropTypes.bool,
   uncutPages: PropTypes.bool,
-  style: PropTypes.object
+  style: PropTypes.object,
+  height: PropTypes.number,
+  width: PropTypes.number
 }
 
 export default FlipPage


### PR DESCRIPTION
As noted by @Antham22 in issue #5, there was no documentation of props `height` and `width`.

This fixes it.