### PR TITLE
Add support for className

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ There are a few properties that define the behaviour of the component, here they
 | `height` | `number` | `480` | Height for the flipboard |
 | `width` | `number` | `320` | Width for the flipboard |
 | `onPageChange` | `function` |   | Callback when the page has been changed. Parameter: `pageIndex` |
+| `className` | `string` | `''` | Optional CSS class to be applied on the container |
 
 ## Methods
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -380,6 +380,16 @@
         }
       }
     }, {
+      key: '_beforeItem',
+      value: function _beforeItem() {
+        return !this.isFirstPage() ? this.props.children[this.state.page - 1] : this.props.firstComponent;
+      }
+    }, {
+      key: '_afterItem',
+      value: function _afterItem() {
+        return !this.isLastPage() ? this.props.children[this.state.page + 1] : this.props.lastComponent;
+      }
+    }, {
       key: 'reset',
       value: function reset() {
         this.setState({
@@ -415,10 +425,12 @@
         var gradientBottom = '0 100px 100px -100px rgba(0,0,0,0.25) inset';
         var gradientRight = '100px 0 100px -100px rgba(0,0,0,0.25) inset';
 
+        var complementaryStyle = {
+          height: height
+        };
+
         var pageItem = (0, _react.cloneElement)(page, {
-          style: Object.assign({}, page.props.style, {
-            height: height
-          })
+          style: Object.assign({}, page.props.style, complementaryStyle)
         });
 
         var style = {
@@ -544,9 +556,16 @@
           }
         };
 
-        var beforeItem = !this.isFirstPage() ? this.props.children[this.state.page - 1] : this.props.firstComponent;
+        var beforeItem = this._beforeItem();
+        var afterItem = this._afterItem();
 
-        var afterItem = !this.isLastPage() ? this.props.children[this.state.page + 1] : this.props.lastComponent;
+        var clonedBeforeItem = beforeItem && (0, _react.cloneElement)(beforeItem, {
+          style: Object.assign({}, beforeItem.props.style, complementaryStyle)
+        });
+
+        var clonedAfterItem = afterItem && (0, _react.cloneElement)(afterItem, {
+          style: Object.assign({}, afterItem.props.style, complementaryStyle)
+        });
 
         var container = style.container,
             part = style.part,
@@ -584,7 +603,7 @@
           _react2.default.createElement(
             'div',
             { style: m(part, before, cut) },
-            beforeItem,
+            clonedBeforeItem,
             _react2.default.createElement('div', { style: mask })
           ),
           _react2.default.createElement(
@@ -593,7 +612,7 @@
             _react2.default.createElement(
               'div',
               { style: pull },
-              afterItem
+              clonedAfterItem
             ),
             _react2.default.createElement('div', { style: mask })
           ),
@@ -619,7 +638,7 @@
                 _react2.default.createElement(
                   'div',
                   { style: pull },
-                  beforeItem
+                  clonedBeforeItem
                 )
               ),
               _react2.default.createElement('div', { style: m(gradient, gradientFirstHalfBack) })
@@ -648,7 +667,7 @@
               _react2.default.createElement(
                 'div',
                 { style: m(part, after, cut) },
-                afterItem
+                clonedAfterItem
               ),
               _react2.default.createElement('div', { style: m(gradient, gradientSecondHalfBack) })
             )
@@ -666,12 +685,17 @@
           width: this.getWidth()
         });
 
+        var _props2 = this.props,
+            children = _props2.children,
+            className = _props2.className;
+
+
         // all the pages are rendered once, to prevent glitching
         // (React would reload the child page and cause a image glitch)
         return _react2.default.createElement(
           'div',
-          { style: style },
-          _react.Children.map(this.props.children, function (page, key) {
+          { style: style, className: className },
+          _react.Children.map(children, function (page, key) {
             return _this7.renderPage(page, key);
           })
         );
@@ -696,7 +720,8 @@
     style: {},
     height: 480,
     width: 320,
-    onPageChange: function onPageChange() {}
+    onPageChange: function onPageChange() {},
+    className: ''
   };
 
   FlipPage.propTypes = {
@@ -718,7 +743,8 @@
     style: _propTypes2.default.object,
     height: _propTypes2.default.number,
     width: _propTypes2.default.number,
-    onPageChange: _propTypes2.default.func
+    onPageChange: _propTypes2.default.func,
+    className: _propTypes2.default.string
   };
 
   exports.default = FlipPage;

--- a/src/index.js
+++ b/src/index.js
@@ -278,6 +278,18 @@ class FlipPage extends Component {
     }
   }
 
+  _beforeItem() {
+    return !this.isFirstPage()
+      ? this.props.children[this.state.page - 1]
+      : this.props.firstComponent
+  }
+
+  _afterItem() {
+    return !this.isLastPage()
+      ? this.props.children[this.state.page + 1]
+      : this.props.lastComponent
+  }
+
   reset () {
     this.setState({
       startY: -1,
@@ -306,10 +318,12 @@ class FlipPage extends Component {
     const gradientBottom = '0 100px 100px -100px rgba(0,0,0,0.25) inset'
     const gradientRight = '100px 0 100px -100px rgba(0,0,0,0.25) inset'
 
+    const complementaryStyle = {
+      height: height
+    };
+
     const pageItem = cloneElement(page, {
-      style: Object.assign({}, page.props.style, {
-        height: height
-      })
+      style: Object.assign({}, page.props.style, complementaryStyle)
     })
 
     const style = {
@@ -435,13 +449,16 @@ class FlipPage extends Component {
       }
     }
 
-    const beforeItem = !this.isFirstPage() ? (
-      this.props.children[this.state.page - 1]
-    ) : this.props.firstComponent
+    const beforeItem = this._beforeItem()
+    const afterItem = this._afterItem()
 
-    const afterItem = !this.isLastPage() ? (
-      this.props.children[this.state.page + 1]
-    ) : this.props.lastComponent
+    const clonedBeforeItem = beforeItem && cloneElement(beforeItem, {
+      style: Object.assign({}, beforeItem.props.style, complementaryStyle)
+    })
+
+    const clonedAfterItem = afterItem && cloneElement(afterItem, {
+      style: Object.assign({}, afterItem.props.style, complementaryStyle)
+    })
 
     const {
       container, part, visiblePart, firstHalf, secondHalf, face, back, before, after, cut, pull, gradient, gradientSecondHalfBack, gradientFirstHalfBack, gradientSecondHalf, gradientFirstHalf, mask, zIndex
@@ -458,13 +475,13 @@ class FlipPage extends Component {
         onTouchEnd={this.stopMoving}
         onMouseLeave={this.reset}
         style={container}
-        >
+      >
         <div style={m(part, before, cut)}>
-          {beforeItem}
+          {clonedBeforeItem}
           <div style={mask} />
         </div>
         <div style={m(part, cut, after)}>
-          <div style={pull}>{afterItem}</div>
+          <div style={pull}>{clonedAfterItem}</div>
           <div style={mask} />
         </div>
         <div style={m(part, visiblePart, firstHalf, this.state.firstHalfStyle)}>
@@ -474,7 +491,7 @@ class FlipPage extends Component {
           </div>
           <div style={m(face, back)}>
             <div style={cut}>
-              <div style={pull}>{beforeItem}</div>
+              <div style={pull}>{clonedBeforeItem}</div>
             </div>
             <div style={m(gradient, gradientFirstHalfBack)} />
           </div>
@@ -488,7 +505,7 @@ class FlipPage extends Component {
           </div>
           <div style={m(face, back)}>
             <div style={m(part, after, cut)}>
-              {afterItem}
+              {clonedAfterItem}
             </div>
             <div style={m(gradient, gradientSecondHalfBack)} />
           </div>
@@ -504,11 +521,13 @@ class FlipPage extends Component {
       width: this.getWidth()
     })
 
+    const { children, className } = this.props;
+
     // all the pages are rendered once, to prevent glitching
     // (React would reload the child page and cause a image glitch)
     return (
-      <div style={style}>
-        {Children.map(this.props.children, (page, key) => this.renderPage(page, key))}
+      <div style={style} className={className}>
+        {Children.map(children, (page, key) => this.renderPage(page, key))}
       </div>
     )
   }
@@ -529,7 +548,8 @@ FlipPage.defaultProps = {
   style: {},
   height: 480,
   width: 320,
-  onPageChange: () => {}
+  onPageChange: () => {},
+  className: ''
 }
 
 FlipPage.propTypes = {
@@ -554,7 +574,8 @@ FlipPage.propTypes = {
   style: PropTypes.object,
   height: PropTypes.number,
   width: PropTypes.number,
-  onPageChange: PropTypes.func
+  onPageChange: PropTypes.func,
+  className: PropTypes.string
 }
 
 export default FlipPage


### PR DESCRIPTION
The component did not allow a `className` property to be used.

Also, the items before & after the current item did not have the `className` copied, resulting in re-render bug.