### PR TITLE
Add direction parameter to onPageChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are a few properties that define the behaviour of the component, here they
 | `style` | `object` | `{}` | Additional style for the flipboard |
 | `height` | `number` | `480` | Height for the flipboard |
 | `width` | `number` | `320` | Width for the flipboard |
-| `onPageChange` | `function` |   | Callback when the page has been changed. Parameters: `pageIndex, direction` |
+| `onPageChange` | `function` |   | Callback when the page has been changed. Parameters: `pageIndex`, `direction` |
 | `onStartSwiping` | `function` |   | Callback when the user starts swiping |
 | `onStopSwiping` | `function` |   | Callback when the user stops swiping |
 | `className` | `string` | `''` | Optional CSS class to be applied on the container |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ There are a few properties that define the behaviour of the component, here they
 | `style` | `object` | `{}` | Additional style for the flipboard |
 | `height` | `number` | `480` | Height for the flipboard |
 | `width` | `number` | `320` | Width for the flipboard |
-| `onPageChange` | `function` |   | Callback when the page has been changed. Parameter: `pageIndex` |
+| `onPageChange` | `function` |   | Callback when the page has been changed. Parameters: `pageIndex, direction` |
 | `onStartSwiping` | `function` |   | Callback when the user starts swiping |
 | `onStopSwiping` | `function` |   | Callback when the user stops swiping |
 | `className` | `string` | `''` | Optional CSS class to be applied on the container |

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -94,7 +94,7 @@ class FlipPage extends Component {
     const { page } = this.state;
     this.setState({
       page: (page + 1) % lastPage,
-    }, () => this.props.onPageChange(this.state.page));
+    }, () => this.props.onPageChange(this.state.page, 'next'));
   }
 
   decrementPage() {
@@ -109,7 +109,7 @@ class FlipPage extends Component {
     }
     this.setState({
       page: nextPage,
-    }, () => this.props.onPageChange(this.state.page));
+    }, () => this.props.onPageChange(this.state.page, 'prev'));
   }
 
   hasNextPage() {


### PR DESCRIPTION
Small but usefull change. Added second paremeter direction to onPageChange prop. Now function returns two parameters pageIndex and direction: `'prev'/'next'`. For example it needed if other components state depends on page direction etc.