### PR TITLE
Add noShadow property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.5.7
+
+### Added
+
+- Added a `noShadow` property that disables the inset drop shadow (which is in fact a gradient) on the inside of the flipping pages.
+
 ## 1.5.3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.5.7
+## 1.6.0
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ There are a few properties that define the behaviour of the component, here they
 | `startAt` | `number` | `0` | Default start position of the component |
 | `reverse` | `boolean` | `false` | If `true`, the user must swip in reverse order: he must swipe down/right to see the next page, and up/left to see the previous page. |
 | `swipeImmune` | `array` | `[]` | This array holds the CSS class names that the user can not initiate a swipe gesture from. |
+| `noShadow` | `boolean` | `false` | This disables the inset drop shadow on the inside of the flipping pages. |
 
 ## Methods
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "react-flip-page",
-    "version": "1.5.7",
+    "version": "1.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-flip-page",
-    "version": "1.5.7",
+    "version": "1.6.0",
     "description": "A React.js implementation of the Flipboard page swipe.",
     "main": "dist/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "pretest": "check-dependencies",
         "build": "webpack",
         "lint": "eslint --ext .jsx --ext .js --ignore-pattern *spec* --quiet src/",
-        "test": "jest",
+        "test": "jest -u",
         "test:coverage": "jest --coverage"
     },
     "precommit": [
@@ -68,7 +68,7 @@
         "babel-core": "^7.0.0-bridge.0",
         "babel-eslint": "^10.0.1",
         "babel-jest": "^23.6.0",
-        "babel-loader": "8.0.5",
+        "babel-loader": "8.0.6",
         "check-dependencies": "^1.1.0",
         "css-loader": "^2.0.1",
         "enzyme": "^3.6.0",

--- a/src/__snapshots__/index.spec.jsx.snap
+++ b/src/__snapshots__/index.spec.jsx.snap
@@ -6,7 +6,7 @@ exports[`<FlipPage flipOnTouch /> should include two touch zones 1`] = `"<div st
 
 exports[`<FlipPage flipOnTouch showTouchHint /> should include a touch hint element 1`] = `"<div style=\\"height:480px;position:relative;width:320px\\" class=\\"\\"><div><div role=\\"presentation\\" style=\\"height:10%;position:absolute;touch-action:none;width:100%;z-index:3;left:0;top:0\\" class=\\"rfp-touchZone rfp-touchZone-previous\\"></div><div role=\\"presentation\\" style=\\"height:10%;position:absolute;touch-action:none;width:100%;z-index:3;bottom:0;right:0\\" class=\\"rfp-touchZone rfp-touchZone-next\\"></div><div class=\\"rfp-touchHint rfp-touchHint--vertical\\"></div></div></div>"`;
 
-exports[`<FlipPage flipOnTouch showTouchHint /> should include a touch hint element 2`] = `"<div style=\\"height:480px;position:relative;width:320px\\" class=\\"\\"><div><div role=\\"presentation\\" style=\\"height:10%;position:absolute;touch-action:none;width:100%;z-index:3;left:0;top:0\\" class=\\"rfp-touchZone rfp-touchZone-previous\\"></div><div role=\\"presentation\\" style=\\"height:10%;position:absolute;touch-action:none;width:100%;z-index:3;bottom:0;right:0\\" class=\\"rfp-touchZone rfp-touchZone-next\\"></div><div class=\\"rfp-touchHint rfp-touchHint--vertical\\"></div></div></div>"`;
+exports[`<FlipPage noShadow /> should not have gradient elements 1`] = `"<div style=\\"height:480px;position:relative;width:320px\\" class=\\"\\"></div>"`;
 
 exports[`<FlipPage orientation /> should allow "horizontal" as an orientation entry 1`] = `"<div style=\\"height:480px;position:relative;width:320px\\" class=\\"\\"></div>"`;
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -466,6 +466,7 @@ class FlipPage extends Component {
       flipOnTouch,
       disableSwipe,
       reverse,
+      noShadow,
     } = this.props;
 
     const style = generateStyles(
@@ -557,7 +558,7 @@ class FlipPage extends Component {
               {pageItem}
             </div>
             <div style={m(mask, maskReverse)} />
-            <div style={m(gradient, gradientFirstHalf)} />
+            {!noShadow && <div style={m(gradient, gradientFirstHalf)} />}
           </div>
           <div style={m(face, back)}>
             <div style={cut}>
@@ -565,7 +566,7 @@ class FlipPage extends Component {
                 {clonedBeforeItem}
               </div>
             </div>
-            <div style={m(gradient, gradientFirstHalfBack)} />
+            {!noShadow && <div style={m(gradient, gradientFirstHalfBack)} />}
           </div>
         </div>
         <div style={m(part, visiblePart, secondHalf, this.state.secondHalfStyle)}>
@@ -576,13 +577,13 @@ class FlipPage extends Component {
               </div>
             </div>
             <div style={m(mask, maskReverse)} />
-            <div style={m(gradient, gradientSecondHalf)} />
+            {!noShadow && <div style={m(gradient, gradientSecondHalf)} />}
           </div>
           <div style={m(face, back)}>
             <div style={m(part, after, cut, firstCut)}>
               {clonedAfterItem}
             </div>
-            <div style={m(gradient, gradientSecondHalfBack)} />
+            {!noShadow && <div style={m(gradient, gradientSecondHalfBack)} />}
           </div>
         </div>
       </div>
@@ -705,6 +706,7 @@ FlipPage.defaultProps = {
   startAt: 0,
   reverse: false,
   swipeImmune: [],
+  noShadow: false,
 };
 
 FlipPage.propTypes = {
@@ -742,6 +744,7 @@ FlipPage.propTypes = {
   startAt: PropTypes.number,
   reverse: PropTypes.bool,
   swipeImmune: PropTypes.arrayOf(PropTypes.string),
+  noShadow: PropTypes.bool,
 };
 
 export default FlipPage;

--- a/src/index.spec.jsx
+++ b/src/index.spec.jsx
@@ -784,9 +784,9 @@ describe('<FlipPage flipOnTouch showTouchHint />', () => {
   });
 });
 
-describe('<FlipPage flipOnTouch showTouchHint />', () => {
-  it('should include a touch hint element', () => {
-    const wrapper = shallow(<FlipPage flipOnTouch showTouchHint />);
+describe('<FlipPage noShadow />', () => {
+  it('should not have gradient elements', () => {
+    const wrapper = shallow(<FlipPage noShadow />);
     expect(wrapper.html()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This property fixes a use case needed by @Susan123456789.

It allows to remove the inset drop shadow effect on flipping pages.